### PR TITLE
feat: manual kill counter per campaign entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grudgekeeper",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Total War: Warhammer III – Campaign progression tracker",
   "main": "electron-main.js",
   "scripts": {

--- a/src/index.css
+++ b/src/index.css
@@ -13,3 +13,8 @@ body {
 button {
   font-family: inherit;
 }
+
+input[type=number]::-webkit-inner-spin-button,
+input[type=number]::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+}

--- a/src/views/RoadmapView.jsx
+++ b/src/views/RoadmapView.jsx
@@ -12,10 +12,14 @@ const isDone = (val) => val?.done ?? !!val;
 const getVictory = (val) => val?.victory ?? null;
 const getKills = (val) => val?.kills ?? 0;
 
+
 export default function RoadmapView({ roadmap, checked, setChecked, activeCampaign, setActiveCampaign, activeTier, setActiveTier }) {
     const t = useTheme();
     const [openEntry, setOpenEntry] = useState(null);
     const [victoryModal, setVictoryModal] = useState(null);
+    const [killsModal, setKillsModal] = useState(null);
+    const [killInput, setKillInput] = useState(0);
+
 
     const tier = roadmap.find((r) => r.tier === activeTier) || roadmap[0];
     if (!tier) return null;
@@ -27,6 +31,7 @@ export default function RoadmapView({ roadmap, checked, setChecked, activeCampai
             return n;
         });
         setVictoryModal(null);
+        setKillsModal({ key, lord: victoryModal.lord });
     };
 
     const uncomplete = (key) => {
@@ -61,6 +66,29 @@ export default function RoadmapView({ roadmap, checked, setChecked, activeCampai
                             ))}
                         </div>
                         <button onClick={() => setVictoryModal(null)} style={{ marginTop: 16, fontSize: 12, color: t.text4, background: "transparent", border: "none", cursor: "pointer", fontFamily: "inherit" }}>Cancel</button>
+                    </div>
+                </div>
+            )}
+
+            {killsModal && (
+                <div onClick={() => setKillsModal(null)} style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.7)", zIndex: 200, display: "flex", alignItems: "center", justifyContent: "center" }}>
+                    <div onClick={(e) => e.stopPropagation()} style={{ background: t.bg2, border: `1px solid ${t.border}`, borderRadius: 14, padding: "30px 36px", minWidth: 340, boxShadow: "0 20px 60px rgba(0,0,0,0.5)", textAlign: "center" }}>
+                        <div style={{ fontSize: 28, marginBottom: 10 }}>⚔️</div>
+                        <div style={{ fontSize: 10, letterSpacing: 4, color: t.text4, textTransform: "uppercase", marginBottom: 6 }}>Kill Count</div>
+                        <div style={{ fontSize: 18, color: t.text1, marginBottom: 4 }}>{killsModal.lord}</div>
+                        <div style={{ fontSize: 13, color: t.text4, marginBottom: 18 }}>How many lords did you slay?</div>
+                        <input
+                            autoFocus
+                            type="number"
+                            value={killInput || ""}
+                            placeholder="0"
+                            onChange={(e) => setKillInput(Number(e.target.value))}
+                            style={{ fontSize: 22, padding: "10px 16px", borderRadius: 8, border: `1px solid ${t.border}`, background: t.input, color: "#f97316", fontFamily: "inherit", width: "100%", boxSizing: "border-box", textAlign: "center", marginBottom: 18, outline: "none" }}
+                        />
+                        <div style={{ display: "flex", gap: 10, justifyContent: "center" }}>
+                            <button onClick={() => { saveKills(killsModal.key, killInput); setKillInput(0); setKillsModal(null); }} style={{ fontSize: 13, padding: "10px 24px", borderRadius: 8, cursor: "pointer", background: "rgba(249,115,22,0.15)", border: "1px solid rgba(249,115,22,0.5)", color: "#f97316", fontFamily: "inherit" }}>Confirm</button>
+                            <button onClick={() => { setKillInput(0); setKillsModal(null); }} style={{ fontSize: 13, padding: "10px 24px", borderRadius: 8, cursor: "pointer", background: "transparent", border: `1px solid ${t.border}`, color: t.text4, fontFamily: "inherit" }}>Skip</button>
+                        </div>
                     </div>
                 </div>
             )}
@@ -100,7 +128,7 @@ export default function RoadmapView({ roadmap, checked, setChecked, activeCampai
                             <div style={{ padding: isOpen ? "20px 22px" : "15px 16px", flex: 1 }}>
 
                                 <div style={{ display: "flex", alignItems: "flex-start", gap: 10, marginBottom: 9 }}>
-                                    <div onClick={(e) => { e.stopPropagation(); if (done) { uncomplete(key); } else { setVictoryModal({ key, faction: entry.faction }); } }} style={{ width: 21, height: 21, borderRadius: 4, flexShrink: 0, border: `1px solid ${done ? "#4ade80" : t.inputBorder}`, background: done ? "rgba(74,222,128,0.18)" : "transparent", display: "flex", alignItems: "center", justifyContent: "center", fontSize: 12, color: "#4ade80", transition: "all 0.2s", marginTop: 2, cursor: "pointer" }}>{done && "✓"}</div>
+                                    <div onClick={(e) => { e.stopPropagation(); if (done) { uncomplete(key); } else { setVictoryModal({ key, faction: entry.faction, lord: entry.lord }); } }} style={{ width: 21, height: 21, borderRadius: 4, flexShrink: 0, border: `1px solid ${done ? "#4ade80" : t.inputBorder}`, background: done ? "rgba(74,222,128,0.18)" : "transparent", display: "flex", alignItems: "center", justifyContent: "center", fontSize: 12, color: "#4ade80", transition: "all 0.2s", marginTop: 2, cursor: "pointer" }}>{done && "✓"}</div>
                                     <div style={{ flex: 1 }}>
                                         <div style={{ display: "flex", alignItems: "center", gap: 7, marginBottom: 2, flexWrap: "wrap" }}>
                                             <span style={{ fontSize: isOpen ? 19 : 15, color: done ? t.text5 : t.text1, textDecoration: done ? "line-through" : "none" }}>{entry.faction}</span>
@@ -143,7 +171,7 @@ export default function RoadmapView({ roadmap, checked, setChecked, activeCampai
                                                 </div>
                                                 <div style={{ display: "flex", gap: 7 }}>
                                                     <button onClick={(e) => { e.stopPropagation(); const n = activeCampaign === entry.id ? null : entry.id; save("tww3_activeCampaign", n); setActiveCampaign(n); }} style={{ flex: 1, fontSize: 11, padding: "6px 0", borderRadius: 6, cursor: "pointer", background: activeCampaign === entry.id ? `${cl}25` : "transparent", border: `1px solid ${cl}50`, color: cl, fontFamily: "inherit" }}>{activeCampaign === entry.id ? "▶ Active" : "▷ Start"}</button>
-                                                    <button onClick={(e) => { e.stopPropagation(); if (done) { uncomplete(key); } else { setVictoryModal({ key, faction: entry.faction }); } }} style={{ flex: 1, fontSize: 11, padding: "6px 0", borderRadius: 6, cursor: "pointer", background: done ? "rgba(74,222,128,0.15)" : "transparent", border: `1px solid ${done ? "#4ade80" : t.border}`, color: done ? "#4ade80" : t.text3, fontFamily: "inherit" }}>{done ? `✓ ${victory ?? "Done"}` : "Complete"}</button>
+                                                    <button onClick={(e) => { e.stopPropagation(); if (done) { uncomplete(key); } else { setVictoryModal({ key, faction: entry.faction, lord: entry.lord }); } }} style={{ flex: 1, fontSize: 11, padding: "6px 0", borderRadius: 6, cursor: "pointer", background: done ? "rgba(74,222,128,0.15)" : "transparent", border: `1px solid ${done ? "#4ade80" : t.border}`, color: done ? "#4ade80" : t.text3, fontFamily: "inherit" }}>{done ? `✓ ${victory ?? "Done"}` : "Complete"}</button>
                                                     <div>
                                                         {done && (
                                                             <div style={{ display: "flex", alignItems: "center", gap: 6 }}>

--- a/src/views/RoadmapView.jsx
+++ b/src/views/RoadmapView.jsx
@@ -10,8 +10,9 @@ const VICTORY_COLORS = { Short: "#facc15", Long: "#4ade80", Ultimate: "#c084fc" 
 
 const isDone = (val) => val?.done ?? !!val;
 const getVictory = (val) => val?.victory ?? null;
+const getKills = (val) => val?.kills ?? 0;
 
-export default function RoadmapView({ roadmap, checked, setChecked, activeCampaign, setActiveCampaign, activeTier, setActiveTier }) {
+export default function RoadmapView({ roadmap, checked, setChecked, activeCampaign, setActiveCampaign, activeTier, setActiveTier, }) {
     const t = useTheme();
     const [openEntry, setOpenEntry] = useState(null);
     const [victoryModal, setVictoryModal] = useState(null);
@@ -85,6 +86,7 @@ export default function RoadmapView({ roadmap, checked, setChecked, activeCampai
                     const victory = getVictory(checked[key]);
                     const isPlaying = activeCampaign === entry.id;
                     const cl = tier.tierColor;
+                    const kills = getKills(checked[key]);
 
                     return (
                         <div key={key} onClick={() => setOpenEntry(isOpen ? null : key)} style={{
@@ -142,6 +144,14 @@ export default function RoadmapView({ roadmap, checked, setChecked, activeCampai
                                                 <div style={{ display: "flex", gap: 7 }}>
                                                     <button onClick={(e) => { e.stopPropagation(); const n = activeCampaign === entry.id ? null : entry.id; save("tww3_activeCampaign", n); setActiveCampaign(n); }} style={{ flex: 1, fontSize: 11, padding: "6px 0", borderRadius: 6, cursor: "pointer", background: activeCampaign === entry.id ? `${cl}25` : "transparent", border: `1px solid ${cl}50`, color: cl, fontFamily: "inherit" }}>{activeCampaign === entry.id ? "▶ Active" : "▷ Start"}</button>
                                                     <button onClick={(e) => { e.stopPropagation(); if (done) { uncomplete(key); } else { setVictoryModal({ key, faction: entry.faction }); } }} style={{ flex: 1, fontSize: 11, padding: "6px 0", borderRadius: 6, cursor: "pointer", background: done ? "rgba(74,222,128,0.15)" : "transparent", border: `1px solid ${done ? "#4ade80" : t.border}`, color: done ? "#4ade80" : t.text3, fontFamily: "inherit" }}>{done ? `✓ ${victory ?? "Done"}` : "Complete"}</button>
+                                                    <div>
+                                                        {done && (
+                                                            <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                                                                <span style={{ fontSize: 12, color: cl }}>Kills:</span>
+                                                                <input onClick={(e) => { e.stopPropagation(); }} type="number" value={kills || ""} placeholder="Kills" onChange={e => { e.stopPropagation(); saveKills(key, Number(e.target.value)); }} style={{ flex: 1, fontSize: 12, fontWeight: "bold", padding: "6px 0", paddingLeft: 8, borderRadius: 6, width: "100%", minWidth: 0, background: t.input, border: `1px solid ${cl}50`, color: cl, fontFamily: "inherit" }} />
+                                                            </div>
+                                                        )}
+                                                    </div>
                                                 </div>
                                             </div>
                                         </div>

--- a/src/views/RoadmapView.jsx
+++ b/src/views/RoadmapView.jsx
@@ -36,6 +36,14 @@ export default function RoadmapView({ roadmap, checked, setChecked, activeCampai
         });
     };
 
+    const saveKills = (key, kills) => {
+        setChecked((p) => {
+            const n = { ...p, [key]: { ...p[key], kills } };
+            save("tww3_checked", n);
+            return n;
+        });
+    };
+
     return (
         <div style={{ display: "flex", flexDirection: "column", height: "100%", overflow: "hidden" }}>
 

--- a/src/views/RoadmapView.jsx
+++ b/src/views/RoadmapView.jsx
@@ -12,7 +12,7 @@ const isDone = (val) => val?.done ?? !!val;
 const getVictory = (val) => val?.victory ?? null;
 const getKills = (val) => val?.kills ?? 0;
 
-export default function RoadmapView({ roadmap, checked, setChecked, activeCampaign, setActiveCampaign, activeTier, setActiveTier, }) {
+export default function RoadmapView({ roadmap, checked, setChecked, activeCampaign, setActiveCampaign, activeTier, setActiveTier }) {
     const t = useTheme();
     const [openEntry, setOpenEntry] = useState(null);
     const [victoryModal, setVictoryModal] = useState(null);

--- a/src/views/Statistic.jsx
+++ b/src/views/Statistic.jsx
@@ -33,7 +33,7 @@ export default function Statistics({ roadmap, checked, customList }) {
 
     const sumKills = doneEntries.reduce((sum, e) => sum + e.kills, 0);
     const avgKills = doneEntries.length > 0 ? (sumKills / doneEntries.length).toFixed(1) : "—";
-    const topKills = doneEntries.sort((a, b) => b.kills - a.kills).slice(0, 5);
+    const topKills = [...doneEntries].sort((a, b) => b.kills - a.kills).slice(0, 5);
 
     const tagCounts = doneEntries.flatMap(e => e.tags).reduce((acc, tag) => {
         acc[tag] = (acc[tag] || 0) + 1;

--- a/src/views/Statistic.jsx
+++ b/src/views/Statistic.jsx
@@ -5,6 +5,7 @@ const VICTORY_COLORS = { Short: "#facc15", Long: "#4ade80", Ultimate: "#c084fc" 
 
 const isDone = (val) => val?.done ?? !!val;
 const getVictory = (val) => val?.victory ?? null;
+const getKills = (val) => val?.kills ?? 0;
 
 export default function Statistics({ roadmap, checked, customList }) {
     const t = useTheme();
@@ -16,6 +17,7 @@ export default function Statistics({ roadmap, checked, customList }) {
             tierLabel: tier.tierLabel,
             isDone: isDone(checked[`${tier.tier}-${i}`]),
             victory: getVictory(checked[`${tier.tier}-${i}`]),
+            kills: getKills(checked[`${tier.tier}-${i}`]),
         }))
     );
 
@@ -28,6 +30,10 @@ export default function Statistics({ roadmap, checked, customList }) {
     const avgDifficulty = doneEntries.length > 0
         ? (doneEntries.reduce((sum, e) => sum + e.difficulty, 0) / doneEntries.length).toFixed(1)
         : "—";
+
+    const sumKills = doneEntries.reduce((sum, e) => sum + e.kills, 0);
+    const avgKills = doneEntries.length > 0 ? (sumKills / doneEntries.length).toFixed(1) : "—";
+    const topKills = doneEntries.sort((a, b) => b.kills - a.kills).slice(0, 5);
 
     const tagCounts = doneEntries.flatMap(e => e.tags).reduce((acc, tag) => {
         acc[tag] = (acc[tag] || 0) + 1;
@@ -162,6 +168,38 @@ export default function Statistics({ roadmap, checked, customList }) {
                             <Bar dataKey="done" fill={t.accent} radius={[4, 4, 0, 0]} />
                         </BarChart>
                     </ResponsiveContainer>
+                </div>
+
+                <div style={{ background: t.bg3, border: `1px solid ${t.border}`, borderRadius: 10, padding: "18px 20px" }}>
+                    <div style={{ fontSize: 10, color: t.text4, letterSpacing: 2, textTransform: "uppercase", marginBottom: 16 }}>Kill Statistics</div>
+
+                    <div style={{ display: "flex", gap: 12, marginBottom: 16 }}>
+                        <div style={{ flex: 1, background: t.bg2, borderRadius: 8, padding: "12px 14px", border: `1px solid ${t.border}` }}>
+                            <div style={{ fontSize: 10, color: t.text4, letterSpacing: 1, textTransform: "uppercase", marginBottom: 4 }}>Total Kills</div>
+                            <div style={{ fontSize: 28, color: "#f97316", fontWeight: "normal", lineHeight: 1 }}>{sumKills}</div>
+                            <div style={{ fontSize: 11, color: t.text3, marginTop: 3 }}>across all campaigns</div>
+                        </div>
+                        <div style={{ flex: 1, background: t.bg2, borderRadius: 8, padding: "12px 14px", border: `1px solid ${t.border}` }}>
+                            <div style={{ fontSize: 10, color: t.text4, letterSpacing: 1, textTransform: "uppercase", marginBottom: 4 }}>Avg. per Campaign</div>
+                            <div style={{ fontSize: 28, color: t.accent, fontWeight: "normal", lineHeight: 1 }}>{avgKills}</div>
+                            <div style={{ fontSize: 11, color: t.text3, marginTop: 3 }}>kills on average</div>
+                        </div>
+                    </div>
+
+                    {topKills.length > 0 ? (
+                        <div>
+                            <div style={{ fontSize: 10, color: t.text4, letterSpacing: 2, textTransform: "uppercase", marginBottom: 10 }}>Top Lords by Kills</div>
+                            {topKills.map((e, i) => (
+                                <div key={i} style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 7 }}>
+                                    <span style={{ fontSize: 11, color: t.text4, width: 16, textAlign: "right" }}>#{i + 1}</span>
+                                    <span style={{ flex: 1, fontSize: 13, color: t.text1 }}>{e.lord}</span>
+                                    <span style={{ fontSize: 13, color: "#f97316", fontWeight: "bold" }}>{e.kills}</span>
+                                </div>
+                            ))}
+                        </div>
+                    ) : (
+                        <div style={{ fontSize: 13, color: t.text4, fontStyle: "italic" }}>No kills recorded yet.</div>
+                    )}
                 </div>
 
                 <div style={{ background: t.bg3, border: `1px solid ${t.border}`, borderRadius: 10, padding: "18px 20px", gridColumn: "1 / -1" }}>


### PR DESCRIPTION
## Kill Counter — Manual Kill Tracking

Closes #4

### What this PR does
Adds a manual kill counter input to each campaign entry in the Roadmap view. Players can now log how many kills a lord achieved during a campaign.

### Implementation
- Added `kills` field to the `checked` state (alongside existing `done` and `victory`)
- Added a number input in the expanded campaign card, placed in the header area next to the faction badges
- Kill count is persisted via `usePersist` under `tww3_checked`
- Input is visible when a campaign card is expanded (`isOpen`)

### Notes
Automatic tracking from game files is not possible as the app has no connection to the game — this is intentional manual entry only, as noted in the original issue.