### PR TITLE
fix: resolve playstyle labels and icons from styles.csv

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,7 +3,8 @@ import { ThemeCtx, DARK, LIGHT } from "./context/ThemeContext";
 import usePersist from "./hooks/usePersist";
 import useCSV, {
   buildRoadmap,
-  buildRaces
+  buildRaces,
+  buildStyles
 } from "./hooks/useCSV";
 
 import Dashboard from "./views/Dashboard";
@@ -27,9 +28,11 @@ export default function App() {
   const [showPicker, setShowPicker] = useState(false);
 
   const { data: roadmapCsv, loading: loadingRoadmap } = useCSV("/data/roadmap.csv");
+  const { data: stylesCsv, loading: loadingStyles } = useCSV("/data/styles.csv");
   const { data: racesCsv, loading: loadingRaces } = useCSV("/data/races.csv");
 
-  const roadmap = loadingRoadmap ? [] : buildRoadmap(roadmapCsv);
+  const styles = loadingStyles ? [] : buildStyles(stylesCsv);
+  const roadmap = loadingRoadmap ? [] : buildRoadmap(roadmapCsv, styles);
   const races = loadingRaces ? [] : buildRaces(racesCsv);
 
   const theme = isDark ? DARK : LIGHT;

--- a/src/views/RoadmapView.jsx
+++ b/src/views/RoadmapView.jsx
@@ -142,7 +142,9 @@ export default function RoadmapView({ roadmap, checked, setChecked, activeCampai
 
                                 <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 7 }}>
                                     <DiffDots value={entry.difficulty} color={cl} />
-                                    <span style={{ fontSize: 11, color: t.text3 }}>{entry.style}</span>
+                                    <span style={{ fontSize: 11, color: t.text3 }}>
+                                        {entry.styles?.[0]?.icon} {entry.styles?.[0]?.label}
+                                    </span>
                                 </div>
                                 <div style={{ display: "flex", gap: 5, flexWrap: "wrap" }}>
                                     {entry.tags.map((tag) => <Tag key={tag} label={tag} color={cl} />)}


### PR DESCRIPTION
Closes #7

## What this PR does
Fixes missing playstyle icons and labels in RoadmapView. Styles were previously shown as raw IDs (e.g. "defensive") instead of resolved labels and icons from styles.csv.

## Implementation
- Added `styles.csv` loading in `App.jsx` via `useCSV`
- Imported and called `buildStyles` to build the styles map
- Passed `stylesMap` as second parameter to `buildRoadmap`
- Updated RoadmapView to use `entry.styles?.[0]?.icon` and `entry.styles?.[0]?.label`